### PR TITLE
Added `npm start` support and log listening ip:port

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,3 +12,5 @@ var port = process.env.PORT || 8080;
 app.listen(port);
 
 module.exports = app;
+
+console.log("Listening on http://localhost:" + port)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha",
-    "start": "app.js"
+    "start": "node app.js"
   }
 }


### PR DESCRIPTION
• Now, `npm start` starts app without throwing any error.
• Upon successfully running application, console logs `listening ip:port`